### PR TITLE
#40 - Create a field for storing student data in profile (full name, group)

### DIFF
--- a/app/src/main/java/com/immortalidiot/rutlead/ui/components/fields/constant/FullNameField.kt
+++ b/app/src/main/java/com/immortalidiot/rutlead/ui/components/fields/constant/FullNameField.kt
@@ -1,0 +1,55 @@
+package com.immortalidiot.rutlead.ui.components.fields.constant
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.immortalidiot.rutlead.ui.theme.ThemeColors
+import com.immortalidiot.rutlead.ui.theme.boldInter16
+
+@Composable
+fun FullNameField(
+    modifier: Modifier,
+    firstName: String = "Фамилия",
+    secondName: String = "Имя",
+    thirdName: String = "Отчество",
+    fullNameTextStyle: TextStyle
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "$firstName $secondName",
+            style = fullNameTextStyle,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = thirdName,
+            style = fullNameTextStyle
+        )
+    }
+}
+
+@Preview
+@Composable
+fun FullNameFieldPreview() {
+    FullNameField(
+        modifier = Modifier,
+        fullNameTextStyle = boldInter16.copy(
+            color = if (isSystemInDarkTheme()) {
+                ThemeColors.Dark.header
+            } else {
+                ThemeColors.Light.header
+            }
+        )
+    )
+}

--- a/app/src/main/java/com/immortalidiot/rutlead/ui/components/fields/constant/GroupField.kt
+++ b/app/src/main/java/com/immortalidiot/rutlead/ui/components/fields/constant/GroupField.kt
@@ -1,0 +1,42 @@
+package com.immortalidiot.rutlead.ui.components.fields.constant
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.immortalidiot.rutlead.ui.theme.ThemeColors
+import com.immortalidiot.rutlead.ui.theme.boldLato12
+
+@Composable
+fun GroupField(
+    modifier: Modifier,
+    group: String,
+    groupTextStyle: TextStyle
+) {
+    Text(
+        modifier = modifier,
+        text = "Студент группы: $group",
+        style = groupTextStyle,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Preview
+@Composable
+fun GroupFieldPreview() {
+    GroupField(
+        modifier = Modifier,
+        group = "УВП-212",
+        groupTextStyle = boldLato12.copy(
+            color = if (isSystemInDarkTheme()) {
+                //TODO(): add a custom color for this type of the text
+                ThemeColors.Dark.header
+            } else {
+                ThemeColors.Light.header
+            }
+        )
+    )
+}


### PR DESCRIPTION
The design of the profile in Figma doesn't contains studentID field. I can add it if needed (this is done very easily and quickly)
![image](https://github.com/ImmortalIdiot/RUTLead-Android/assets/127626768/fb6488a5-3278-446e-a32d-4f83dfb95db5)
