### PR TITLE
#51 - Fixed confirm password error

### DIFF
--- a/app/src/main/java/com/immortalidiot/rutlead/presentation/viemodels/auth/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/immortalidiot/rutlead/presentation/viemodels/auth/ResetPasswordViewModel.kt
@@ -77,7 +77,7 @@ class ResetPasswordViewModel : ViewModel() {
             confirmPassword = uiState.value.confirmPassword
         )
 
-        if (email.isFailure || password.isFailure) {
+        if (email.isFailure || password.isFailure || confirmPassword.isFailure) {
             mutableState.update {
                 State.ValidationError(
                     emailError = email.exceptionOrNull()?.message,


### PR DESCRIPTION
When you entered the password in the "Confirm password" field that does not match the password in the "Password" field, an error was not displayed, now the error is displayed