### PR TITLE
#48 - Fix the exit from the app in SignUpScreen

### DIFF
--- a/app/src/main/java/com/immortalidiot/rutlead/presentation/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/immortalidiot/rutlead/presentation/screens/auth/LoginScreen.kt
@@ -197,14 +197,7 @@ fun LoginScreen(
                     RedirectText(
                         modifier = modifier,
                         text = stringResource(id = R.string.to_registration),
-                        onTextClick = {
-                            navHostController.navigate(AuthScreen.SignUpScreen.route) {
-                                popUpTo(0) {
-                                    inclusive = true
-                                    saveState = false
-                                }
-                            }
-                        }
+                        onTextClick = { navHostController.navigate(AuthScreen.SignUpScreen.route) }
                     )
                 }
                 Spacer(modifier = modifier.height(dimensions.verticalXSmall))


### PR DESCRIPTION
Before:
The user opens the application, clicks on "Зарегистрируйтесь". They sends to SignUpScreen. If the user clicks on the system cancel button the application closes.
Now:
The user opens the application, clicks on "Зарегистрируйтесь". They sends to SignUpScreen. If the user clicks on the system cancel button the application doesn't close and the user is moved to the authorization screen